### PR TITLE
added a folder and proposed issue template for new term or class and new property

### DIFF
--- a/issue_templates/01-new-term-or-class.md
+++ b/issue_templates/01-new-term-or-class.md
@@ -1,0 +1,50 @@
+---
+name: New Term or Class Request
+about: Propose that a new term (class) be added to the ontology
+title: "[NTR] "
+labels: new term request
+---
+
+Before submitting, please check that the term does not already exist, e.g. by
+searching an ontology browser such as [OLS](https://www.ebi.ac.uk/ols4/).
+
+## Proposed term label
+The preferred, precise label for the new term.
+
+## Synonyms (optional)
+Any alternative names for the concept. Please indicate the scope of each
+synonym (exact / broad / narrow / related) where possible.
+
+## Definition
+A clear, referenced definition, written so it is understandable to
+non-specialists. Please include a citation (e.g. `PMID:#######` or a DOI)
+supporting the definition where possible.
+
+## Suggested parent term(s)
+Where should this term sit in the ontology's hierarchy? Please give the ID
+and label of the proposed parent term(s), if known.
+
+## Existing terms affected (optional)
+Should any existing terms be reclassified as children under this new term?
+
+## Cross-references (optional)
+Any identifiers or links in other databases/ontologies that support this
+request (e.g. equivalent or related entries elsewhere).
+
+## Motivation
+Explain why this new term or class should be added. If a similar term or class already
+exists elsewhere, explain why it should not simply be re-used/imported
+instead.
+
+## Additional information (optional)
+Anything else relevant to the request that isn't captured above.
+
+## Contributor (optional)
+If you would like to be credited, please provide your ORCID (or similar
+identifier).
+
+## Source reference for template
+This template was synthesized from the templates for similar issue types of OBO Foundry (https://obofoundry.org)
+issue templates. The specific source of each block is specified in the PROVENANCE.md file (link). All repositories used for inspiration for this template is referenced here:
+
+agro/add-term.yml, agro/import-term.yml, cl/a_adding_term.md, cl/a_adding_term_cellxgene.md, fbbi/a_adding_term.md, foodon/new-term-request--ntr-.md, fypo/new-term-request.md, go/metabolic-biosynthetic-catalytic-process---new-term-request.md, go/new-term-request.md, go/ntr--protein-containing-complex.md, mondo/add-gene-related-syndrome.md, mondo/add-term.yml, ms/new_term.yaml, pbpko/add-term.md, so/new-term-request.md, uberon/a_adding_term.md

--- a/issue_templates/02-new-property.md
+++ b/issue_templates/02-new-property.md
@@ -1,0 +1,58 @@
+---
+name: New Property Request
+about: Propose that a new property (relation) be added to the ontology
+title: "Request for adding property [NAME]"
+labels: new property
+---
+
+<!--
+GENERIC TEMPLATE — this action ("request a new property/relation, as opposed
+to a new class term") was found in only one OBO Foundry issue-template set,
+so this template is a direct generalization of that single source with
+ontology-specific wording removed.
+Source: omo/new_property.yml (OBO Metadata Ontology)
+-->
+
+Use this form to request that a new property be added to the ontology.
+
+## IRI (optional)
+If the property already exists elsewhere, provide its full IRI here.
+> Source: omo/new_property.yml
+
+## Label
+What should be the canonical label of the property?
+> Source: omo/new_property.yml
+
+## Definition
+A short definition of the property.
+> Source: omo/new_property.yml
+
+## Parent property (optional)
+If there is a suitable parent property already in the ontology, provide it
+here.
+> Source: omo/new_property.yml
+
+## Range / datatype
+What kind of value does this property take (e.g. string, integer, a class,
+an individual, another property, a URI)?
+> Source: omo/new_property.yml
+
+## Example(s) of use
+Provide at least one example showing the property in use.
+> Source: omo/new_property.yml
+
+## Motivation
+Explain why this property should be added. If a similar property already
+exists elsewhere, explain why it should not simply be re-used/imported
+instead.
+> Source: omo/new_property.yml
+
+## Contributor
+Provide an ORCID, ROR, or Wikidata identifier for attribution and
+provenance.
+> Source: omo/new_property.yml
+
+## Checklist (optional)
+- [ ] This property is generally useful beyond a single, narrow use case.
+- [ ] No existing property in the ontology already covers this use case.
+> Source: omo/new_property.yml


### PR DESCRIPTION
Based on OBO Foundry ontologies with GitHub repositories with a license allowing re-use and modification (CC-BY, CC-0) I have (together with Claude) created a template for generic use for ontology collaborations, in this case specifically for proposing a new term or class and new property.

workflow for creating the template is described in detail here: https://dtudk.sharepoint.com/:w:/r/sites/PREFER/Delte%20dokumenter/GitHub_collaboration_documentation/issue%20templating/[README.docx](https://dtudk.sharepoint.com/:w:/r/sites/PREFER/Delte%20dokumenter/GitHub_collaboration_documentation/issue%20templating/README.docx?d=wf28f0e2c14324813a80821cc83db3410&csf=1&web=1&e=bLWMc5)?d=wf28f0e2c14324813a80821cc83db3410&csf=1&web=1&e=bLWMc5

