### PR TITLE
Enhance contribution guidelines in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ The following is a set of guidelines for contributing to PREFER.
 These guidelines are not strict rules. Use your best judgment, and feel free to propose 
 changes to this document in a pull request.
 
-**Most importantly**, do not be afraid of making mistakes, you will not be able to break anything! We are happy you want to contribute so please do not get overwhelmed with all the information on how to bes contribute, the issue forms will guide you depending on what you see can be improved. If something in your issue does not make sense to the curators, we will contact you for more information.
+**Most importantly**, do not be afraid of making mistakes, you will not be able to break anything! We are happy you want to contribute so please do not get overwhelmed with all the information on how to best contribute, the issue forms will guide you depending on what you see can be improved. If something in your issue does not make sense to the curators, we will contact you for more information.
 
 ## Table Of Contents
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,8 @@ The following is a set of guidelines for contributing to PREFER.
 These guidelines are not strict rules. Use your best judgment, and feel free to propose 
 changes to this document in a pull request.
 
+**Most importantly**, do not be afraid of making mistakes, you will not be able to break anything! We are happy you want to contribute so please do not get overwhelmed with all the information on how to bes contribute, the issue forms will guide you depending on what you see can be improved. If something in your issue does not make sense to the curators, we will contact you for more information.
+
 ## Table Of Contents
 
 - [Guidelines for Contributions and Requests](#contributions)
@@ -22,10 +24,17 @@ changes to this document in a pull request.
 
 <a id="reporting-bugs"></a>
 
-### Reporting problems with the ontology
+### Contribution through issues
 
 Please use our [Issue Tracker](https://github.com/Multiomics-Analytics-Group/prefer_ontology/issues/) for reporting problems with the ontology. 
-To learn how to write a good issue [see here](#great-issues).
+
+In general, to learn how to write a good issue [see here](#great-issues).
+
+Additionally, we have implemented a number of issue forms that will help guide you to provide the necessary information depending on what you have found that needs to be changed. Please select the appropriate issue form for your need: [Select issue form](https://github.com/Multiomics-Analytics-Group/prefer_ontology/issues/new/choose)
+
+Specifically for requesting and/or creating new terms we have a detailed guideline bellow, this is in case you want to contribute by directly proposing an extension of the ontology: [requesting new terms](#requesting-terms).
+
+Otherwise please follow the issue forms and provide as much information as possible to help us with improving the ontology as smoothly as possible.
 
 <a id="requesting-terms"></a>
 


### PR DESCRIPTION
Expanded guidelines for contributing, emphasizing the importance of not being afraid of making mistakes and providing additional resources for issue reporting.

I think it is a nice contribution guideline as it is not too long and it uses links for additional information ensuring that people who "just" want to contribute with an issue is not overwhelmed. I think this is important as -initially- we will hopefully have our current collaborators providing feedback, and they will likely not be very experienced in modifying or proposing changes to an ontology project.